### PR TITLE
feat: cria a rota proxy para busca de músicas no Spotify

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -318,3 +318,20 @@ app.get('/api/v1/spotify/test-token', async (req: any, res: any) => {
         res.status(500).json({ error: 'Falha ao obter o token do Spotify.' });
     }
 });
+
+// rota de teste do token do Spotify
+app.get('/api/v1/spotify/search', requireAuth, async (req: any, res: any) => {
+  const { q } = req.query; // 'q' vem de "query" (busca)
+
+  if (!q) {
+    return res.status(400).json({ error: 'O parâmetro de busca "q" é obrigatório.' });
+  }
+
+  try {
+    const results = await spotifyService.searchTracks(q as string);
+    res.json(results);
+  } catch (error) {
+    console.error('Erro na rota de busca do Spotify:', error);
+    res.status(500).json({ error: 'Erro ao comunicar com o Spotify.' });
+  }
+});

--- a/server/src/services/SpotifyService.ts
+++ b/server/src/services/SpotifyService.ts
@@ -68,4 +68,42 @@ export class SpotifyService {
     // O '!' no final diz ao TypeScript: "Eu garanto que this.token não é nulo aqui."
     return this.token!.accessToken;
   }
+
+  // Cole este método dentro da classe SpotifyService,
+// por exemplo, a seguir ao método getAccessToken()
+
+  public async searchTracks(query: string, limit: number = 20) {
+    const accessToken = await this.getAccessToken();
+    
+    // Constrói os parâmetros da URL de forma segura
+    const searchParams = new URLSearchParams({
+      q: query,
+      type: 'track',
+      limit: limit.toString(),
+    });
+
+    const response = await fetch(`https://api.spotify.com/v1/search?${searchParams.toString()}`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok) {
+      console.error('Falha ao procurar músicas no Spotify:', await response.text());
+      throw new Error('Falha ao procurar músicas no Spotify.');
+    }
+
+    const data = await response.json();
+    
+    // Vamos simplificar os dados antes de os enviar para o front-end
+    return data.tracks.items.map((track: any) => ({
+      id: track.id,
+      name: track.name,
+      artist: track.artists.map((artist: any) => artist.name).join(', '),
+      album: track.album.name,
+      imageUrl: track.album.images[0]?.url, // Pega a primeira imagem (maior) se existir
+      durationMs: track.duration_ms,
+      previewUrl: track.preview_url,
+    }));
+  }
 }


### PR DESCRIPTION
### Descrição

Este Pull Request introduz a funcionalidade necessária no serviço de API do front-end para comunicar com o novo endpoint de busca de músicas do Spotify (`/api/v1/spotify/search`).

### Alterações Realizadas

-   **`client/src/services/api.js`**: Adicionada uma nova função exportada `searchTracks(query)`.
    -   Esta função faz um pedido `GET` para a rota proxy do nosso back-end, passando o termo de busca como parâmetro.
    -   Retorna a lista de músicas formatada pela API.