### PR TITLE
feat: cria a página de resultados de busca e integra o fluxo

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,8 +4,9 @@ import { Container, Box, Button, Typography, CircularProgress } from '@mui/mater
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import SearchResultsPage from './pages/SearchResultsPage'; // 1. Importa a nova página
 import { useAuth } from './context/AuthContext';
-import ProtectedRoute from './components/ProtectedRoute'; // 1. Importe o ProtectedRoute
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   const { isAuthenticated, user, logout, loading } = useAuth();
@@ -56,17 +57,11 @@ function App() {
       </Box>
 
       <Routes>
-        {/* 2. Envolva o elemento da rota que quer proteger com o ProtectedRoute */}
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <HomePage />
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        {/* 2. Adiciona a nova rota para a busca, também protegida */}
+        <Route path="/search" element={<ProtectedRoute><SearchResultsPage /></ProtectedRoute>} />
       </Routes>
     </Container>
   );

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Typography, Box } from '@mui/material';
-import SearchBar from '../components/SearchBar'; // 1. Importe o novo componente
+import SearchBar from '../components/SearchBar';
 
 function HomePage() {
+  const navigate = useNavigate();
 
   const handleSearch = (query) => {
-    // Numa tarefa futura, isto irá redirecionar para a página de resultados.
-    // Por agora, apenas exibimos a busca no console para confirmar que funciona.
-    console.log('A procurar por:', query);
+    // Navega para a página de resultados, passando a busca como um parâmetro de URL
+    navigate(`/search?q=${encodeURIComponent(query)}`);
   };
 
   return (
@@ -18,8 +19,6 @@ function HomePage() {
       <Typography variant="subtitle1" color="text.secondary" sx={{ mb: 4 }}>
         Procure e avalie as suas músicas favoritas.
       </Typography>
-
-      {/* 2. Adicione a SearchBar */}
       <SearchBar onSearch={handleSearch} />
     </Box>
   );

--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { searchTracks } from '../services/api';
+import { 
+  Container, 
+  Typography, 
+  Box, 
+  List, 
+  ListItem, 
+  ListItemAvatar, 
+  Avatar, 
+  ListItemText, 
+  CircularProgress,
+  Alert
+} from '@mui/material';
+
+function SearchResultsPage() {
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('q'); // Lê o parâmetro 'q' do URL
+
+  const [tracks, setTracks] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    // Esta função é chamada sempre que a página carrega ou o 'query' muda
+    const fetchTracks = async () => {
+      if (!query) {
+        setTracks([]);
+        return;
+      }
+
+      setLoading(true);
+      setError('');
+      try {
+        const results = await searchTracks(query);
+        setTracks(results);
+      } catch (err) {
+        setError('Falha ao procurar pelas músicas. Tente novamente.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTracks();
+  }, [query]); // A dependência [query] garante que a busca é refeita se o URL mudar
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>
+        Resultados para: "{query}"
+      </Typography>
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {!loading && !error && tracks.length === 0 && (
+        <Typography>Nenhuma música encontrada.</Typography>
+      )}
+
+      {!loading && !error && tracks.length > 0 && (
+        <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
+          {tracks.map((track) => (
+            <ListItem key={track.id} alignItems="flex-start">
+              <ListItemAvatar>
+                <Avatar variant="square" src={track.imageUrl} alt={track.name} sx={{ width: 56, height: 56, mr: 2 }} />
+              </ListItemAvatar>
+              <ListItemText
+                primary={track.name}
+                secondary={track.artist}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Container>
+  );
+}
+
+export default SearchResultsPage;


### PR DESCRIPTION
### Descrição

Este Pull Request implementa a página de resultados de busca, completando o fluxo principal da funcionalidade de pesquisa de músicas da Sprint 2.

### Alterações Realizadas

-   **`client/src/pages/SearchResultsPage.jsx`**:
    -   Criação de uma nova página que lê o parâmetro de busca `q` do URL usando o hook `useSearchParams`.
    -   Utiliza um `useEffect` para chamar o serviço `searchTracks` quando a página carrega ou o termo de busca muda.
    -   Gere os estados de carregamento, erro e sucesso, exibindo um `CircularProgress`, uma mensagem de `Alert` ou a lista de resultados.
    -   A lista de resultados é renderizada com componentes `List` e `ListItem` do MUI para uma exibição clara.

-   **`client/src/pages/HomePage.jsx`**:
    -   A função `handleSearch` da `SearchBar` foi atualizada para usar `useNavigate` e redirecionar o utilizador para a nova página `/search`, passando o termo da busca como um parâmetro de URL.

-   **`client/src/App.jsx`**:
    -   A nova rota `/search` foi adicionada e protegida com o componente `ProtectedRoute`, garantindo que apenas utilizadores autenticados possam realizar buscas.