### PR TITLE
feat: cria a rota para obter detalhes de uma música específica

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -2,13 +2,24 @@ import axios from 'axios';
 
 // Cria uma instância do Axios com configurações pré-definidas
 const api = axios.create({
-  // URL base de todas as requisições para a nossa API
   baseURL: 'http://localhost:3000/api/v1',
-  
-  // MUITO IMPORTANTE: Esta opção permite que o Axios envie os cookies
-  // recebidos do back-end (como o cookie de sessão) em cada requisição.
-  // Sem isto, a autenticação baseada em sessão não funciona.
   withCredentials: true,
 });
 
+/**
+ * Função para procurar músicas através do nosso back-end.
+ * @param {string} query O termo de busca para a música.
+ * @returns {Promise<Array>} Uma promessa que resolve para um array de músicas.
+ */
+export const searchTracks = async (query) => {
+  const response = await api.get('/spotify/search', {
+    params: {
+      q: query,
+    },
+  });
+  return response.data;
+};
+
+// Esta linha é a exportação padrão
 export default api;
+

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -335,3 +335,16 @@ app.get('/api/v1/spotify/search', requireAuth, async (req: any, res: any) => {
     res.status(500).json({ error: 'Erro ao comunicar com o Spotify.' });
   }
 });
+
+// nova rota para obter detalhes de uma música específica
+app.get('/api/v1/spotify/tracks/:id', requireAuth, async (req: any, res: any) => {
+  const { id } = req.params;
+
+  try {
+    const trackDetails = await spotifyService.getTrackDetails(id);
+    res.json(trackDetails);
+  } catch (error) {
+    console.error(`Erro na rota de detalhes da música ${id}:`, error);
+    res.status(500).json({ error: 'Erro ao obter detalhes da música.' });
+  }
+});

--- a/server/src/services/SpotifyService.ts
+++ b/server/src/services/SpotifyService.ts
@@ -106,4 +106,34 @@ export class SpotifyService {
       previewUrl: track.preview_url,
     }));
   }
+
+  public async getTrackDetails(trackId: string) {
+    const accessToken = await this.getAccessToken();
+
+    const response = await fetch(`https://api.spotify.com/v1/tracks/${trackId}`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok) {
+      console.error(`Falha ao obter detalhes da música ${trackId} do Spotify:`, await response.text());
+      throw new Error('Falha ao obter detalhes da música do Spotify.');
+    }
+
+    const track = await response.json();
+
+    // Vamos formatar os dados para o front-end
+    return {
+      id: track.id,
+      name: track.name,
+      artist: track.artists.map((artist: any) => artist.name).join(', '),
+      album: track.album.name,
+      imageUrl: track.album.images[0]?.url,
+      durationMs: track.duration_ms,
+      previewUrl: track.preview_url,
+      popularity: track.popularity,
+      externalUrl: track.external_urls.spotify,
+    };
+  }
 }


### PR DESCRIPTION
### Descrição

Este Pull Request adiciona um novo endpoint ao back-end, `GET /api/v1/spotify/tracks/:id`, que é essencial para a página de detalhes da música.

### Alterações Realizadas

-   **`server/src/services/SpotifyService.ts`**:
    -   Adicionado um novo método `getTrackDetails(trackId)` que faz um pedido ao endpoint `v1/tracks/{id}` da API do Spotify.
    -   A função formata e retorna um objeto com os detalhes completos de uma única faixa.

-   **`server/src/index.ts`**:
    -   Criada a nova rota `GET /api/v1/spotify/tracks/:id`.
    -   A rota é protegida e utiliza o novo método do `SpotifyService` para obter e retornar os dados da música solicitada.