### PR TITLE
feat: cria a página de detalhes da música e integra o fluxo

### DIFF
--- a/client/src/pages/SearchResultsPage.jsx
+++ b/client/src/pages/SearchResultsPage.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { useSearchParams, Link as RouterLink } from 'react-router-dom';
+import { searchTracks } from '../services/spotify';
+import { 
+  Container, 
+  Typography, 
+  Box, 
+  List, 
+  ListItemAvatar, 
+  Avatar, 
+  ListItemText, 
+  CircularProgress,
+  Alert,
+  ListItemButton
+} from '@mui/material';
+import SearchBar from '../components/SearchBar';
+import { useNavigate } from 'react-router-dom';
+
+function SearchResultsPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const query = searchParams.get('q'); // Lê o parâmetro 'q' do URL
+
+  const [tracks, setTracks] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    // Esta função é chamada sempre que a página carrega ou o 'query' muda
+    const fetchTracks = async () => {
+      if (!query) {
+        setTracks([]);
+        return;
+      }
+
+      setLoading(true);
+      setError('');
+      try {
+        const results = await searchTracks(query);
+        setTracks(results);
+      } catch (err) {
+        setError('Falha ao procurar pelas músicas. Tente novamente.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTracks();
+  }, [query]); // A dependência [query] garante que a busca é refeita se o URL mudar
+
+  const handleSearch = (newQuery) => {
+    navigate(`/search?q=${encodeURIComponent(newQuery)}`);
+  };
+
+  return (
+    <Container>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 2, mb: 4 }}>
+        <SearchBar onSearch={handleSearch} />
+      </Box>
+
+      {query && (
+        <Typography variant="h4" gutterBottom>
+          Resultados para: "{query}"
+        </Typography>
+      )}
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {!loading && !error && tracks.length === 0 && query && (
+        <Typography>Nenhuma música encontrada.</Typography>
+      )}
+
+      {!loading && !error && tracks.length > 0 && (
+        <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
+          {tracks.map((track) => (
+            <ListItemButton 
+              key={track.id} 
+              component={RouterLink} 
+              to={`/music/${track.id}`}
+            >
+              <ListItemAvatar>
+                <Avatar variant="square" src={track.imageUrl} alt={track.name} sx={{ width: 56, height: 56, mr: 2 }} />
+              </ListItemAvatar>
+              <ListItemText
+                primary={track.name}
+                secondary={track.artist}
+              />
+            </ListItemButton>
+          ))}
+        </List>
+      )}
+    </Container>
+  );
+}
+
+export default SearchResultsPage;
+

--- a/client/src/pages/TrackDetailsPage.jsx
+++ b/client/src/pages/TrackDetailsPage.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { getTrackDetails } from '../services/spotify';
+import { 
+  Container, 
+  Typography, 
+  Box, 
+  CircularProgress, 
+  Alert, 
+  Paper, 
+  Grid 
+} from '@mui/material';
+
+function TrackDetailsPage() {
+  const { id } = useParams(); // Obtém o ID da música do URL
+  const [track, setTrack] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchDetails = async () => {
+      try {
+        setLoading(true);
+        setError('');
+        const details = await getTrackDetails(id);
+        setTrack(details);
+      } catch (err) {
+        setError('Falha ao carregar os detalhes da música.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDetails();
+  }, [id]); // Refaz a busca se o ID no URL mudar
+
+  if (loading) {
+    return <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}><CircularProgress /></Box>;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (!track) {
+    return <Typography>Música não encontrada.</Typography>;
+  }
+
+  return (
+    <Container>
+      <Paper sx={{ p: 4, mt: 4 }}>
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={4}>
+            <Box
+              component="img"
+              sx={{
+                width: '100%',
+                height: 'auto',
+                borderRadius: 2,
+              }}
+              alt={track.name}
+              src={track.imageUrl}
+            />
+          </Grid>
+          <Grid item xs={12} md={8}>
+            <Typography variant="h3" component="h1" gutterBottom>
+              {track.name}
+            </Typography>
+            <Typography variant="h5" component="h2" color="text.secondary" gutterBottom>
+              {track.artist}
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Álbum: {track.album}
+            </Typography>
+            {/* Adicionar mais detalhes aqui no futuro */}
+          </Grid>
+        </Grid>
+      </Paper>
+    </Container>
+  );
+}
+
+export default TrackDetailsPage;

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,25 +1,9 @@
 import axios from 'axios';
 
-// Cria uma instância do Axios com configurações pré-definidas
 const api = axios.create({
   baseURL: 'http://localhost:3000/api/v1',
   withCredentials: true,
 });
 
-/**
- * Função para procurar músicas através do nosso back-end.
- * @param {string} query O termo de busca para a música.
- * @returns {Promise<Array>} Uma promessa que resolve para um array de músicas.
- */
-export const searchTracks = async (query) => {
-  const response = await api.get('/spotify/search', {
-    params: {
-      q: query,
-    },
-  });
-  return response.data;
-};
-
-// Esta linha é a exportação padrão
 export default api;
 

--- a/client/src/services/spotify.js
+++ b/client/src/services/spotify.js
@@ -1,0 +1,25 @@
+import api from './api';
+
+/**
+ * Função para procurar músicas através do nosso back-end.
+ * @param {string} query O termo de busca para a música.
+ * @returns {Promise<Array>} Uma promessa que resolve para um array de músicas.
+ */
+export const searchTracks = async (query) => {
+  const response = await api.get('/spotify/search', {
+    params: {
+      q: query,
+    },
+  });
+  return response.data;
+};
+
+/**
+ * Função para obter os detalhes de uma única música.
+ * @param {string} trackId O ID da música no Spotify.
+ * @returns {Promise<Object>} Uma promessa que resolve para um objeto com os detalhes da música.
+ */
+export const getTrackDetails = async (trackId) => {
+  const response = await api.get(`/spotify/tracks/${trackId}`);
+  return response.data;
+};


### PR DESCRIPTION
### Descrição

Este Pull Request finaliza a Sprint 2, implementando a página de detalhes da música e completando todo o fluxo de busca.

### Alterações Realizadas

-   **`client/src/services/spotify.js`**:
    -   Criado um novo ficheiro de serviço dedicado às chamadas da API do Spotify.
    -   A função `searchTracks` foi movida para este ficheiro.
    -   Adicionada uma nova função `getTrackDetails(trackId)` para chamar o novo endpoint do back-end.

-   **`client/src/pages/TrackDetailsPage.jsx`**:
    -   Criada uma nova página que utiliza o hook `useParams` para obter o ID da música a partir do URL.
    -   A página chama o serviço `getTrackDetails` para buscar os dados e exibe-os num layout com imagem e texto.
    -   Gere os estados de carregamento e erro.

-   **`client/src/pages/SearchResultsPage.jsx`**:
    -   Atualizada para usar o novo serviço `spotify.js`.
    -   Cada item da lista de resultados foi transformado num `ListItemButton` que funciona como um link para a nova página de detalhes.

-   **`client/src/App.jsx`**:
    -   Adicionada a nova rota dinâmica `/music/:id` para a página de detalhes, protegida para garantir que apenas utilizadores autenticados a possam aceder.