### PR TITLE
feat: cria a página de perfil do utilizador para exibir avaliações

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,7 +5,8 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import SearchResultsPage from './pages/SearchResultsPage';
-import TrackDetailsPage from './pages/TrackDetailsPage'; // 1. Importe a página de detalhes
+import TrackDetailsPage from './pages/TrackDetailsPage';
+import ProfilePage from './pages/ProfilePage'; // 1. Importe a nova página
 import { useAuth } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
@@ -33,6 +34,12 @@ function App() {
           <Button component={Link} to="/" sx={{ mr: 2 }}>
             Início
           </Button>
+          {/* 2. Adicione o link para o perfil APENAS se estiver autenticado */}
+          {isAuthenticated && (
+             <Button component={Link} to="/profile" sx={{ mr: 2 }}>
+                Meu Perfil
+             </Button>
+          )}
         </nav>
         <Box>
           {isAuthenticated ? (
@@ -62,8 +69,9 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/search" element={<ProtectedRoute><SearchResultsPage /></ProtectedRoute>} />
-        {/* 2. Adicione a nova rota dinâmica para os detalhes da música */}
         <Route path="/music/:id" element={<ProtectedRoute><TrackDetailsPage /></ProtectedRoute>} />
+        {/* 3. Adicione a nova rota para o perfil, protegida */}
+        <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
       </Routes>
     </Container>
   );

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from 'react';
+import { getMyReviews } from '../services/reviews';
+import { useAuth } from '../context/AuthContext';
+import {
+  Container,
+  Typography,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  CircularProgress,
+  Alert,
+  Paper,
+  Divider
+} from '@mui/material';
+import RatingInput from '../components/RatingInput'; // Reutilizamos para mostrar a nota
+
+function ProfilePage() {
+  const { user } = useAuth(); // Obtemos o utilizador logado para exibir o nome
+  const [reviews, setReviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchReviews = async () => {
+      try {
+        setLoading(true);
+        setError('');
+        const myReviews = await getMyReviews();
+        setReviews(myReviews);
+      } catch (err) {
+        setError('Falha ao carregar as suas avaliações.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReviews();
+  }, []); // Executa apenas uma vez ao montar o componente
+
+  return (
+    <Container maxWidth="md">
+      <Paper sx={{ p: 4, mt: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Meu Perfil
+        </Typography>
+        <Typography variant="h6" component="h2" color="text.secondary" gutterBottom>
+          {user?.username}
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="h5" gutterBottom>
+          Minhas Avaliações
+        </Typography>
+
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {error && <Alert severity="error">{error}</Alert>}
+
+        {!loading && !error && reviews.length === 0 && (
+          <Typography sx={{ mt: 2 }}>Você ainda não avaliou nenhuma música.</Typography>
+        )}
+
+        {!loading && !error && reviews.length > 0 && (
+          <List sx={{ width: '100%' }}>
+            {reviews.map((review) => (
+              <ListItem key={review.id} divider>
+                <ListItemText
+                  primary={`ID da Música: ${review.trackId}`}
+                  // Poderíamos adicionar um link para /music/:trackId aqui
+                  secondary={
+                    <RatingInput value={review.rating} readOnly={true} />
+                  }
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </Paper>
+    </Container>
+  );
+}
+
+export default ProfilePage;

--- a/client/src/services/reviews.js
+++ b/client/src/services/reviews.js
@@ -1,4 +1,4 @@
- import api from './api';
+import api from './api';
 
 /**
  * Obtém a avaliação de um utilizador para uma música específica.
@@ -35,4 +35,14 @@ export const saveReview = async (trackId, rating, existingReviewId = null) => {
   }
 };
 
-// Poderíamos adicionar aqui a função deleteReview se necessário no futuro
+/**
+ * Obtém todas as avaliações do utilizador autenticado.
+ * @returns {Promise<Array>} Uma promessa que resolve para um array de avaliações.
+ */
+export const getMyReviews = async () => {
+  const response = await api.get('/users/me/reviews');
+  return response.data;
+};
+
+// Não precisamos de 'export default' neste ficheiro, pois exportamos várias funções nomeadas.
+


### PR DESCRIPTION
### Descrição

Este Pull Request conclui a Sprint 3, implementando a página de perfil pessoal onde o utilizador autenticado pode visualizar a lista das suas músicas avaliadas.

### Alterações Realizadas

-   **`client/src/services/reviews.js`**:
    -   Adicionada a função `getMyReviews()` que chama o endpoint `GET /api/v1/users/me/reviews` para buscar as avaliações do utilizador.

-   **`client/src/pages/ProfilePage.jsx`**:
    -   Criada uma nova página que usa `useEffect` para chamar `getMyReviews` ao ser montada.
    -   Exibe o nome de utilizador obtido do `AuthContext`.
    -   Mostra uma lista das avaliações do utilizador, renderizando o `trackId` e a `rating` (usando o componente `RatingInput` em modo `readOnly`).
    -   Inclui tratamento para estados de carregamento, erro e caso o utilizador não tenha nenhuma avaliação.

-   **`client/src/App.jsx`**:
    -   Adicionada a nova rota `/profile`, protegida por `ProtectedRoute`.
    -   Adicionado um link "Meu Perfil" no menu de navegação superior, visível apenas para utilizadores autenticados.